### PR TITLE
Introduce multi-stage build for optimal image size and security

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,75 @@
+# Git files
+.git
+.gitignore
+.gitattributes
+
+# Python cache and build artifacts
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Virtual environments
+venv/
+env/
+ENV/
+.venv/
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Documentation and assets
+*.md
+assets/
+*.jpg
+*.png
+*.gif
+
+# Testing and linting
+.pytest_cache/
+.coverage
+.coveragerc
+.tox/
+.cache
+pytest.ini
+.pylintrc
+
+# Development tools config
+.pre-commit-config.yaml
+poetry.lock
+pyproject.toml
+.python-version
+
+# Logs
+*.log
+logs/
+
+# Temporary files
+*.tmp
+*.temp
+.tmp/
+.temp/ 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,31 @@
-FROM python:3.11
+# ================================
+# Stage 1: Build stage
+# ================================
+FROM python:3.11-slim as builder
 
-# Install gsutil and dependencies securely
-RUN apt-get update && apt-get install -y \
+# Install build dependencies in a single layer
+RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     jq \
     bzip2 \
     gnupg \
     ca-certificates \
     apt-transport-https \
-    lsb-release && \
-    curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+    lsb-release \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Google Cloud SDK
+RUN curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
     | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" \
     > /etc/apt/sources.list.d/google-cloud-sdk.list && \
     apt-get update && \
-    apt-get install -y google-cloud-sdk && \
-    apt-get clean
+    apt-get install -y --no-install-recommends google-cloud-sdk && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
-# Get latest version tag dynamically and download + install binary
+# Get logjuicer latest version tag dynamically and download + install binary
 RUN set -eux; \
     LATEST_VERSION=$(curl -s https://api.github.com/repos/logjuicer/logjuicer/releases/latest | jq -r .tag_name); \
     DOWNLOAD_URL="https://github.com/logjuicer/logjuicer/releases/download/${LATEST_VERSION}/logjuicer-x86_64-linux.tar.bz2"; \
@@ -26,17 +34,53 @@ RUN set -eux; \
     chmod +x /usr/local/bin/logjuicer; \
     rm /tmp/logjuicer.tar.bz2
 
+# Copy requirements first for better layer caching
+COPY requirements.txt .
+
+# Install Python dependencies to a target directory for easy copying
+RUN pip install --no-cache-dir --target /app-packages -r requirements.txt
+
+# ================================
+# Stage 2: Runtime stage
+# ================================
+FROM python:3.11-slim as runtime
+
+# Install only runtime system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    jq \
+    ca-certificates \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user for security
+RUN groupadd -r appuser && useradd -r -g appuser -d /app -s /bin/bash appuser
+
+# Copy Python packages from builder stage
+COPY --from=builder /app-packages /app-packages
+
+# Copy Google Cloud SDK from builder stage
+COPY --from=builder /usr/lib/google-cloud-sdk /usr/lib/google-cloud-sdk
+COPY --from=builder /usr/bin/gcloud /usr/bin/gcloud
+COPY --from=builder /usr/bin/gsutil /usr/bin/gsutil
+
+# Copy logjuicer binary from builder stage
+COPY --from=builder /usr/local/bin/logjuicer /usr/local/bin/logjuicer
+
 # Set working directory
 WORKDIR /app
 
-# Copy source code
-COPY . .
+# Copy source code (do this last for better layer caching)
+COPY --chown=appuser:appuser . .
 
-# Install Python dependencies
-RUN pip install --no-cache-dir -r requirements.txt
-
-# Disable buffering
+# Set environment variables
 ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONPATH="/app-packages:$PYTHONPATH"
+ENV PATH="/usr/lib/google-cloud-sdk/bin:$PATH"
+
+# Switch to non-root user
+USER appuser
 
 # Default command
 CMD ["python3", "slack.py"]


### PR DESCRIPTION
This PR introduces a multi-stage build with slim base image, which reduces the resulting image size from 2.35 GB to 1.07 GB. As a side effect, image build times for code-only changes have also decreased from over 30 seconds to below 10 seconds.