### PR TITLE
Fix Slack bot getting stuck on irrelevant messages by updating timestamp

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -17,6 +17,7 @@ load_dotenv()  # Load environment variables
 
 SLACK_BOT_TOKEN = os.getenv("SLACK_BOT_TOKEN", None)
 SLACK_CHANNEL_ID = os.getenv("SLACK_CHANNEL_ID", None)
+JEDI_BOT_SLACK_USER_ID = os.getenv("JEDI_BOT_SLACK_USER_ID", None)
 
 
 def get_product_config(product_name: str):


### PR DESCRIPTION
The Slack bot would stop responding if the most recent message in the channel was not relevant (e.g., didn't contain the word "failure"). This happened because last_seen_timestamp wasn't updated for such messages, causing the bot to fetch and reprocess the same irrelevant message in a loop.

Updated _process_message to return the message timestamp even for skipped messages. This ensures the bot continues scanning forward in the channel, regardless of message relevance.