### PR TITLE
Build logs cmd line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Python 3.11 and above is recommended for the environment setup.
 ```
 python3 slack.py --help
 
-usage: slack.py [-h] [--product PRODUCT] [--ci CI]
+usage: slack.py [-h] [--product PRODUCT] [--ci CI] [--build-logs BUILD_LOGS] [--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [--enable-inference]
 
 Slack Log Analyzer Bot
 
@@ -28,6 +28,11 @@ options:
   -h, --help            show this help message and exit
   --product PRODUCT     Product type (e.g., openshift, ansible)
   --ci CI               CI system name
+  --build-logs BUILD_LOGS
+                        Build logs for job comparison
+  --log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
+                        Logging level (e.g., DEBUG, INFO, WARNING, ERROR, CRITICAL). Can also be set via LOG_LEVEL env var
+  --enable-inference    Enable inference mode. Can also be set via ENABLE_INFERENCE env var (true/false).
 ```
 
 ## **Configurables**

--- a/src/log_analyzer.py
+++ b/src/log_analyzer.py
@@ -37,14 +37,14 @@ from src.utils import extract_job_details
 logger = logging.getLogger(__name__)
 
 
-def download_and_analyze_logs(text, ci_system):
+def download_and_analyze_logs(text, ci_system, build_log_repo):
     """Extract job details, download and analyze logs based on CI system."""
     if ci_system == "PROW":
         job_url, job_name = extract_job_details(text)
         if job_url is None or job_name is None:
             return None, None, None
         directory_path = download_prow_logs(job_url)
-        errors_list, categorization_message, requires_llm, is_install_issue = analyze_prow_artifacts(directory_path, job_name)
+        errors_list, categorization_message, requires_llm, is_install_issue = analyze_prow_artifacts(directory_path, job_name, build_log_repo)
     else:
         # Pre-assumes the other ci system is ansible
         url_pattern = r"<([^>]+)>"

--- a/src/log_summarizer.py
+++ b/src/log_summarizer.py
@@ -151,7 +151,7 @@ def download_prow_logs(url, output_dir="/tmp/"):
     return log_dir
 
 
-def get_logjuicer_extract(directory_path, job_name):
+def get_logjuicer_extract(directory_path, job_name, build_log_repo):
     """Extracts erros using logjuicer using fallback mechanism.
 
     :param directory_path: path of output directory
@@ -159,7 +159,7 @@ def get_logjuicer_extract(directory_path, job_name):
     :return: a list of errors
     """
     file_path = os.path.join(directory_path, f"{job_name}.txt")
-    url = f"https://raw.githubusercontent.com/vishnuchalla/ocp-qe-prow-build-logs/main/{job_name}.txt"
+    url = f"{build_log_repo}{job_name}.txt"
 
     try:
         logger.info("Attempting to download log file from: %s", url)
@@ -209,7 +209,7 @@ def get_logmine_extract(directory_path):
         return full_errors
 
 
-def search_prow_errors(directory_path, job_name):
+def search_prow_errors(directory_path, job_name, build_log_repo):
     """
     Extracts errors by using multiple mechanisms.
 
@@ -217,7 +217,7 @@ def search_prow_errors(directory_path, job_name):
     :param directory_path: job name for the failure
     :return: a list of errors
     """
-    logjuicer_extract = get_logjuicer_extract(directory_path, job_name)
+    logjuicer_extract = get_logjuicer_extract(directory_path, job_name, build_log_repo)
     if logjuicer_extract is None:
         return get_logmine_extract(directory_path)
     return logjuicer_extract

--- a/src/prow_analyzer.py
+++ b/src/prow_analyzer.py
@@ -62,7 +62,7 @@ def scan_orion_xmls(directory_path):
     return []
 
 
-def analyze_prow_artifacts(directory_path, job_name):
+def analyze_prow_artifacts(directory_path, job_name, build_log_repo):
     """
     Analyzes prow artifacts and extracts errors.
 
@@ -114,6 +114,6 @@ def analyze_prow_artifacts(directory_path, job_name):
     if len(cluster_operator_errors) == 0:
         orion_errors = scan_orion_xmls(directory_path)
         if len(orion_errors) == 0:
-            return [matched_line] + [step_summary] + search_prow_errors(directory_path, job_name), categorization_message, True, False
+            return [matched_line] + [step_summary] + search_prow_errors(directory_path, job_name, build_log_repo), categorization_message, True, False
         return [matched_line + "\n"] + orion_errors, categorization_message, False, False
     return [matched_line + "\n"] + cluster_operator_errors, categorization_message, False, False


### PR DESCRIPTION
Adding build logs option to be able to use on different CI type of jobs(ie chaos). Set default to the value the build logs were hard coded to so shouldn't need changes in other 

Ex:
`
python3 slack.py --ci prow --product openshift --build-logs https://raw.githubusercontent.com/paigerube14/chaos-build-logs/refs/heads/main
`