### PR TITLE
Add JSON output parsing instead of XML

### DIFF
--- a/bugzooka/analysis/jsonparser.py
+++ b/bugzooka/analysis/jsonparser.py
@@ -1,0 +1,50 @@
+import re
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def extract_json_changepoints(json_data):
+    """
+    Extract changepoints from JSON changepoint summaries.
+
+    :param json_data: List of changepoint records
+    :return: list of changepoint strings
+    """
+    changepoints = []
+    for entry in json_data:
+        if not entry.get("is_changepoint", False):
+            continue
+
+        build_url = entry.get("buildUrl", "N/A")
+        metrics = entry.get("metrics", {})
+
+        for metric_name, metric_data in metrics.items():
+            percentage = metric_data.get("percentage_change", 0)
+            if percentage != 0:  # only flag actual changepoints
+                label_string = metric_data.get("labels", "")
+                url = re.sub(r"X+-X+", "ocp-qe-perfscale", build_url.strip(), count=1)
+                changepoints.append(
+                    f"{label_string} {metric_name} regression detection --- {percentage} % changepoint --- {url}"
+                )
+
+    return changepoints
+
+
+def summarize_orion_json(json_path):
+    """
+    Summarize a given json file.
+
+    :param json_path: json file path
+    :return: summary of the json file
+    """
+    with open(json_path, "r") as f:
+        json_data = json.load(f)
+    summaries = []
+    changepoints = extract_json_changepoints(json_data)
+    for entry in json_data:
+        if entry.get("is_changepoint", False):
+            for cp in changepoints:
+                summaries.append(f"\n--- Test Case: {cp} ---")
+    return "".join(summaries)

--- a/bugzooka/analysis/prow_analyzer.py
+++ b/bugzooka/analysis/prow_analyzer.py
@@ -6,10 +6,8 @@ from collections import deque
 from pathlib import Path
 from bugzooka.core.constants import BUILD_LOG_TAIL, MAINTENANCE_ISSUE
 from bugzooka.analysis.log_summarizer import search_prow_errors
-from bugzooka.analysis.xmlparser import (
-    summarize_orion_xml,
-    summarize_junit_operator_xml,
-)
+from bugzooka.analysis.xmlparser import summarize_junit_operator_xml
+from bugzooka.analysis.jsonparser import summarize_orion_json
 
 logger = logging.getLogger(__name__)
 
@@ -45,19 +43,19 @@ def get_cluster_operator_errors(directory_path):
         return []
 
 
-def scan_orion_xmls(directory_path):
+def scan_orion_jsons(directory_path):
     """
-    Extracts errors from orion xmls.
+    Extracts errors from orion jsons.
 
     :param directory_path: directory path for the artifacts
     :return: list of errors
     """
     base_dir = Path(f"{directory_path}/orion")
-    xml_files = base_dir.glob("*.xml")
-    for xml_file in xml_files:
-        xml_content = summarize_orion_xml(xml_file)
-        if xml_content != "":
-            return [xml_content]
+    json_files = base_dir.glob("*.json")
+    for json_file in json_files:
+        json_content = summarize_orion_json(json_file)
+        if json_content != "":
+            return [json_content]
     return []
 
 
@@ -149,7 +147,7 @@ def analyze_prow_artifacts(directory_path, job_name):
         )
     cluster_operator_errors = get_cluster_operator_errors(directory_path)
     if len(cluster_operator_errors) == 0:
-        orion_errors = scan_orion_xmls(directory_path)
+        orion_errors = scan_orion_jsons(directory_path)
         if len(orion_errors) == 0:
             return (
                 [matched_line]

--- a/bugzooka/analysis/xmlparser.py
+++ b/bugzooka/analysis/xmlparser.py
@@ -1,4 +1,3 @@
-import re
 import logging
 import xmltodict
 
@@ -16,27 +15,6 @@ def load_xml_as_dict(xml_path):
     """
     with open(xml_path, "r", encoding="utf-8") as f:
         return xmltodict.parse(f.read())
-
-
-def extract_orion_changepoint_context(failure_text):
-    """
-    Extracts changepoints.
-
-    :param failure_text: failures xml text
-    :return: list of changepoint strings
-    """
-    lines = str(failure_text).strip().splitlines()
-    changepoints = []
-    for line in lines:
-        if "-- changepoint" in line:
-            parts = line.split("|")
-            try:
-                percentage = parts[-2].strip()
-                url = re.sub(r"X+-X+", "ocp-qe-perfscale", parts[4].strip(), count=1)
-                changepoints.append(f"{percentage} % changepoint --- {url}")
-            except Exception:
-                continue
-    return changepoints
 
 
 def get_failing_test_cases(xml_path):
@@ -58,22 +36,6 @@ def get_failing_test_cases(xml_path):
         for each_case in ts["testcase"]:
             if "failure" in each_case:
                 yield each_case
-
-
-def summarize_orion_xml(xml_path):
-    """
-    Summarize a given xml file.
-
-    :param xml_path: xml file path
-    :return: summary of the xml file
-    """
-    summaries = []
-    for each_case in get_failing_test_cases(xml_path):
-        failure_output = each_case["failure"]
-        changepoint_entries = extract_orion_changepoint_context(failure_output)
-        for entry in changepoint_entries:
-            summaries.append(f"\n--- Test Case: {each_case['@name']} --- {entry}")
-    return "".join(summaries)
 
 
 def summarize_junit_operator_xml(xml_path):


### PR DESCRIPTION
### Description
Move from reading JSON instead of XML from orion output in CI.
Pre-requisite: https://github.com/cloud-bulldozer/orion/pull/192 needs to be merged and our CI needs to be updated with it.

### Testing
Tested and verified in a hacky way in local.
```
vchalla@vchalla-thinkpadp1gen2:~/myforks/BugZooka/bugzooka/analysis$ python3 jsonparser.py 

--- Test Case: [Jira: PerfScale] podReadyLatency_P99 regression detection --- 50.0 % changepoint --- https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.20-nightly-x86-payload-control-plane-6nodes/1945711780562997248 ---
--- Test Case: [Jira: Node] kubelet_avg regression detection --- 26.7327941809839 % changepoint --- https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.20-nightly-x86-payload-control-plane-6nodes/1945711780562997248 ---

```