### PR TITLE
Missing Langchain mcp adapters

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiohappyeyeballs==2.6.1
 aiohttp==3.11.14
 aiosignal==1.3.2
 annotated-types==0.7.0
-anyio==4.4.0
+anyio==4.5.0
 astroid==3.3.10
 attrs==25.3.0
 backports.tarfile==1.2.0
@@ -50,6 +50,7 @@ langchain==0.3.26
 langchain-community==0.3.27
 langchain-core>=0.3.68,<0.4.0
 langchain-text-splitters==0.3.8
+langchain-mcp-adapters==0.1.10
 langsmith==0.4.4
 logmine==0.4.1
 markdown-it-py==3.0.0
@@ -101,7 +102,7 @@ tqdm==4.67.1
 trove-classifiers==2025.1.6.15
 truststore==0.9.2
 typing-inspect==0.9.0
-typing_extensions==4.12.2
+typing_extensions==4.14.0
 unearth==0.17.2
 urllib3==2.3.0
 virtualenv==20.28.1


### PR DESCRIPTION
Rebased with main and hitting this issue 

```
Traceback (most recent call last):
  File "/app/bugzooka/entrypoint.py", line 14, in <module>
    from bugzooka.integrations.slack_fetcher import SlackMessageFetcher
  File "/app/bugzooka/integrations/slack_fetcher.py", line 19, in <module>
    from bugzooka.analysis.log_analyzer import (
  File "/app/bugzooka/analysis/log_analyzer.py", line 35, in <module>
    from bugzooka.integrations.mcp_client import (
  File "/app/bugzooka/integrations/mcp_client.py", line 3, in <module>
    from langchain_mcp_adapters.client import MultiServerMCPClient
ModuleNotFoundError: No module named 'langchain_mcp_adapters'
```