### PR TITLE
feat: add orion visualization links for successful job runs

### DIFF
--- a/bugzooka/analysis/log_summarizer.py
+++ b/bugzooka/analysis/log_summarizer.py
@@ -218,15 +218,17 @@ def construct_visualization_url(view_url, step_name):
     :return: str, dict[str, str], or None
     """
     if step_name and "orion-report" in step_name:
-        return _construct_deferred_viz_urls(view_url)
+        return construct_all_orion_viz_urls(view_url)
     return _construct_single_viz_url(view_url, step_name)
 
 
-def _construct_deferred_viz_urls(view_url):
+def construct_all_orion_viz_urls(view_url):
     """
-    For the deferred orion-report step, find viz HTML files in each
-    individual orion step's artifacts directory and return a dict of
-    {test_name: url}.
+    Find viz HTML files in each individual orion step's artifacts directory
+    and return a dict of {test_name: url}.
+
+    :param view_url: prow view URL
+    :return: dict[str, str] mapping test names to viz URLs, or None
     """
     try:
         gcs_path = extract_gcs_path(view_url)

--- a/bugzooka/integrations/slack_fetcher.py
+++ b/bugzooka/integrations/slack_fetcher.py
@@ -18,6 +18,7 @@ from bugzooka.analysis.log_summarizer import (
     classify_failure_type,
     build_summary_sections,
     construct_visualization_url,
+    construct_all_orion_viz_urls,
 )
 from bugzooka.analysis.prompts import RAG_AWARE_PROMPT
 from bugzooka.integrations.inference_client import (
@@ -451,6 +452,39 @@ class SlackMessageFetcher(SlackClientBase):
         # Check for expected RAG artifacts (JSON index/store files)
         return any(f.name.endswith(".json") for f in os.scandir(rag_dir))
 
+    def _handle_success_viz(self, msg):
+        """Post orion visualization links for a successful job run."""
+        try:
+            text = msg.get("text", "")
+            ts = msg.get("ts")
+
+            view_url, _ = extract_job_details(text)
+            if not view_url:
+                return
+
+            viz_urls = construct_all_orion_viz_urls(view_url)
+            if not viz_urls:
+                return
+
+            header_text = ":chart_with_upwards_trend: *Orion Visualization*\n"
+            for test_name, url in viz_urls.items():
+                header_text += f":white_check_mark: <{url}|{test_name}>\n"
+
+            message_block = self.get_slack_message_blocks(
+                markdown_header=header_text,
+                content_text="",
+                use_markdown=True,
+            )
+            self.client.chat_postMessage(
+                channel=self.channel_id,
+                text="Orion Visualization",
+                blocks=message_block,
+                thread_ts=ts,
+            )
+            self.logger.info("Posted orion viz links for successful job")
+        except Exception as e:
+            self.logger.error("Failed to handle success viz: %s", e)
+
     def _process_message(self, msg, enable_inference):
         """Process a single message through the complete pipeline."""
         user = msg.get("user", "Unknown")
@@ -475,6 +509,11 @@ class SlackMessageFetcher(SlackClientBase):
                 lookback_seconds=lookback,
                 verbose=verbose,
             )
+            return ts
+
+        # Handle success messages: post orion viz links if available
+        if "ended with" in text_lower and "success" in text_lower:
+            self._handle_success_viz(msg)
             return ts
 
         # No weekly trigger; dynamic summarize only

--- a/tests/test_slack_fetcher.py
+++ b/tests/test_slack_fetcher.py
@@ -173,22 +173,63 @@ class TestSlackFetcher:
 
         verify_slack_messages(posted_messages, inference_available=False)
 
-    def test_success_processing(
+    def test_success_processing_with_viz(
         self,
         mock_slack_post_message,
         mock_slack_file_upload,
         mock_slack_conversations_history,
     ):
-        """Test processing success messages, should not post anything to Slack."""
+        """Test processing success messages posts orion viz links when available."""
         test_messages = create_test_messages(include_error=False, include_success=True)
 
-        posted_messages = run_slack_fetcher_test(
-            test_messages=test_messages,
-            enable_inference=False,
-            mock_slack_post_message=mock_slack_post_message,
-            mock_slack_file_upload=mock_slack_file_upload,
-            mock_slack_conversations_history=mock_slack_conversations_history,
-        )
+        mock_viz_urls = {
+            "cluster-density": "https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/artifacts/viz.html",
+            "node-density": "https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/artifacts/viz2.html",
+        }
+
+        with patch(
+            "bugzooka.integrations.slack_fetcher.construct_all_orion_viz_urls",
+            return_value=mock_viz_urls,
+        ):
+            posted_messages = run_slack_fetcher_test(
+                test_messages=test_messages,
+                enable_inference=False,
+                mock_slack_post_message=mock_slack_post_message,
+                mock_slack_file_upload=mock_slack_file_upload,
+                mock_slack_conversations_history=mock_slack_conversations_history,
+            )
+
+        assert (
+            len(posted_messages) == 1
+        ), f"Expected 1 posted message (viz links), got {len(posted_messages)}"
+
+        viz_message = posted_messages[0]
+        blocks = viz_message.get("blocks", [])
+        header_text = blocks[0].get("text", {}).get("text", "")
+        assert "Orion Visualization" in header_text
+        assert "cluster-density" in header_text
+        assert "node-density" in header_text
+
+    def test_success_processing_no_viz(
+        self,
+        mock_slack_post_message,
+        mock_slack_file_upload,
+        mock_slack_conversations_history,
+    ):
+        """Test processing success messages posts nothing when no orion artifacts exist."""
+        test_messages = create_test_messages(include_error=False, include_success=True)
+
+        with patch(
+            "bugzooka.integrations.slack_fetcher.construct_all_orion_viz_urls",
+            return_value=None,
+        ):
+            posted_messages = run_slack_fetcher_test(
+                test_messages=test_messages,
+                enable_inference=False,
+                mock_slack_post_message=mock_slack_post_message,
+                mock_slack_file_upload=mock_slack_file_upload,
+                mock_slack_conversations_history=mock_slack_conversations_history,
+            )
 
         assert (
             len(posted_messages) == 0


### PR DESCRIPTION
## Summary

Orion visualization links were previously only posted for changepoint/orion **failure** jobs. This PR extends that behavior to also post visualization links as threaded replies on **successful** job notifications, giving the team quick access to performance trend charts regardless of job outcome.

## Changes

### `bugzooka/analysis/log_summarizer.py`
- Renamed `_construct_deferred_viz_urls` → `construct_all_orion_viz_urls` to expose it as a public function for reuse outside the failure pipeline.
- Updated the internal call site in `construct_visualization_url` to use the new name.
- No changes to function body or return type.

### `bugzooka/integrations/slack_fetcher.py`
- Added `construct_all_orion_viz_urls` to imports.
- Added success message detection in `_process_message()`: messages matching `"ended with" + "success"` are routed to the new handler, placed **after** the summarize trigger and **before** the failure gate.
- Added `_handle_success_viz()` method that:
  - Extracts the Prow URL from the message.
  - Scans GCS for Orion visualization HTML artifacts via `construct_all_orion_viz_urls`.
  - Posts a threaded reply with `:white_check_mark:` links per test if artifacts are found.
  - Silently skips if no Orion artifacts exist (consistent with non-orion failure behavior).
  - Wraps everything in a try/except to avoid crashing the poll loop.

### `tests/test_slack_fetcher.py`
- Replaced `test_success_processing` (which asserted zero messages) with two new tests:
  - `test_success_processing_with_viz` — mocks viz URLs present, asserts 1 message posted with correct content.
  - `test_success_processing_no_viz` — mocks viz URLs as `None`, asserts 0 messages posted.

## What is NOT changed

- Failure pipeline (download → analyze → preview → job history → LLM) is completely untouched.
- Summarize feature, socket mode listener, RAG augmentation, and deduplication logic are unaffected.
- No new dependencies added.

## Test plan

- [x] All 21 unit tests pass (`SLACK_BOT_TOKEN=xoxb-test SLACK_APP_TOKEN=xapp-test make test`)
- [x] `ruff check` passes with no errors
- [x] Manual smoke test: copied a real success message into a test Slack channel, confirmed viz links were posted as a threaded reply
- [x] Manual verification: `construct_all_orion_viz_urls` returns correct GCS URLs for a real Prow job
- [x] Confirmed failure messages still trigger the full analysis pipeline as before

/cc @mohit-sheth 