### PR TITLE
fix: update version regex to support OpenShift 5.x and beyond

### DIFF
--- a/bugzooka/integrations/slack_fetcher.py
+++ b/bugzooka/integrations/slack_fetcher.py
@@ -384,8 +384,8 @@ class SlackMessageFetcher(SlackClientBase):
                     "failure" in text_lower or "error" in text_lower
                 ):
                     total_failures += 1
-                    # Extract OpenShift version like 4.19, 4.20, etc., if present
-                    vm = re.search(r"\b4\.\d{1,2}\b", text_lower)
+                    # Extract OpenShift version like 4.19, 4.20, 5.0 etc., if present
+                    vm = re.search(r"\b\d+\.\d{1,2}\b", text_lower)
                     v = vm.group(0) if vm else None
                     if v:
                         version_counts[v] = version_counts.get(v, 0) + 1


### PR DESCRIPTION
The previous regex pattern only matched 4.x versions (e.g., 4.19, 4.22). Updated to support all major versions including 5.0 and future releases.