### PR TITLE
Capturing Bugzooka Usage metrics

### DIFF
--- a/bugzooka/analysis/log_analyzer.py
+++ b/bugzooka/analysis/log_analyzer.py
@@ -142,7 +142,10 @@ def download_and_analyze_logs(text):
 
 
 def filter_errors_with_llm(errors_list, requires_llm):
-    """Filter errors using LLM."""
+    """Filter errors using LLM.
+
+    :return: Tuple of (result_text, retry_count)
+    """
     client = get_inference_client()
 
     @_with_retry
@@ -170,11 +173,16 @@ def filter_errors_with_llm(errors_list, requires_llm):
         message = client.chat(messages=error_prompt)
         return message.content or ""
 
-    return _filter()
+    result = _filter()
+    retry_count = _filter.statistics.get("attempt_number", 1) - 1
+    return result, retry_count
 
 
 def run_agent_analysis(error_summary):
-    """Run agent analysis on the error summary with retry logic."""
+    """Run agent analysis on the error summary with retry logic.
+
+    :return: Tuple of (result_text, retry_count)
+    """
 
     async def _run_async():
         if mcp_module.mcp_client is None:
@@ -217,4 +225,6 @@ def run_agent_analysis(error_summary):
                 f"Unhandled error during analysis: {type(e).__name__}: {str(e)}"
             ) from e
 
-    return _run()
+    result = _run()
+    retry_count = _run.statistics.get("attempt_number", 1) - 1
+    return result, retry_count

--- a/bugzooka/core/config.py
+++ b/bugzooka/core/config.py
@@ -194,3 +194,53 @@ def get_es_channel_mappings() -> dict:
         raise ValueError("ES_CHANNEL_MAPPINGS cannot be empty")
 
     return mappings
+
+
+def get_telemetry_config() -> dict:
+    """
+    Get telemetry configuration from environment variables.
+
+    :return: Dict with es_server, index_prefix, flush_interval, batch_size
+    :raises ValueError: If TELEMETRY_ES_SERVER not set
+    """
+    config = {
+        "es_server": os.getenv("TELEMETRY_ES_SERVER", ""),
+        "index_prefix": os.getenv("TELEMETRY_ES_INDEX_PREFIX", "bugzooka-telemetry"),
+        "flush_interval": int(os.getenv("TELEMETRY_FLUSH_INTERVAL", "30")),
+        "batch_size": int(os.getenv("TELEMETRY_BATCH_SIZE", "50")),
+    }
+
+    if not config["es_server"]:
+        raise ValueError(
+            "TELEMETRY_ES_SERVER is required"
+        )
+
+    return config
+
+
+def get_channel_team_mappings() -> dict:
+    """
+    Get mapping of Slack channel IDs to team names for telemetry.
+
+    Reads CHANNEL_TEAM_MAPPINGS env var (JSON string). Returns empty dict if unset.
+
+    Example: CHANNEL_TEAM_MAPPINGS='{"C12345":"OCP-PerfScale","C67890":"Telco"}'
+
+    :return: Dict mapping channel_id -> team_name
+    """
+    mappings_json = os.getenv("CHANNEL_TEAM_MAPPINGS")
+    if not mappings_json:
+        return {}
+
+    try:
+        mappings = json.loads(mappings_json)
+    except json.JSONDecodeError as e:
+        logging.getLogger(__name__).warning(
+            "Invalid CHANNEL_TEAM_MAPPINGS JSON: %s, using empty mappings", e
+        )
+        return {}
+
+    if not isinstance(mappings, dict):
+        return {}
+
+    return mappings

--- a/bugzooka/entrypoint.py
+++ b/bugzooka/entrypoint.py
@@ -4,6 +4,8 @@ import os
 import signal
 import threading
 
+from bugzooka import telemetry
+
 from bugzooka.core.config import (
     SLACK_CHANNEL_ID,
     configure_logging,
@@ -47,6 +49,8 @@ def main() -> None:
     configure_logging(args.log_level)
     logger = logging.getLogger(__name__)
 
+    telemetry.start()
+
     kwargs = {
         "enable_inference": args.enable_inference,
     }
@@ -78,6 +82,7 @@ def main() -> None:
         logger.info("Received shutdown signal")
         if listener:
             listener.shutdown(signum, frame)
+        telemetry.shutdown()
         fetcher.shutdown(signum, frame)
 
     signal.signal(signal.SIGINT, shutdown_handler)

--- a/bugzooka/integrations/inference_client.py
+++ b/bugzooka/integrations/inference_client.py
@@ -122,6 +122,10 @@ class InferenceClient:
         self.frequency_penalty = frequency_penalty
         self.retry_config = retry_config
 
+        # Telemetry accumulators (reset per agentic call)
+        self.last_total_tokens = 0
+        self.last_tool_calls_count = 0
+
         # Create custom HTTP client with SSL configuration
         if not verify_ssl:
             logger.warning("SSL certificate verification disabled for %s", base_url)
@@ -193,6 +197,7 @@ class InferenceClient:
             response = self.client.chat.completions.create(**api_kwargs)
 
             # Log token usage if available
+            usage_data = None
             if hasattr(response, "usage") and response.usage:
                 usage = response.usage
                 logger.info(
@@ -201,8 +206,18 @@ class InferenceClient:
                     usage.completion_tokens,
                     usage.total_tokens,
                 )
+                usage_data = {
+                    "prompt_tokens": usage.prompt_tokens,
+                    "completion_tokens": usage.completion_tokens,
+                    "total_tokens": usage.total_tokens,
+                }
 
-            return response.choices[0].message
+            message = response.choices[0].message
+            try:
+                message._token_usage = usage_data
+            except (AttributeError, TypeError):
+                object.__setattr__(message, "_token_usage", usage_data)
+            return message
 
         except httpx.TimeoutException as e:
             logger.error("Request timed out after %s seconds: %s", self.timeout, e)
@@ -254,6 +269,9 @@ class InferenceClient:
         """
         logger.debug("Starting agentic loop with %d messages", len(messages))
 
+        total_tokens_accumulated = 0
+        tool_calls_count = 0
+
         iteration = 0
         while iteration < max_iterations:
             iteration += 1
@@ -266,6 +284,11 @@ class InferenceClient:
                 temperature=temperature,
                 tools=tools,
             )
+
+            if hasattr(message, "_token_usage") and message._token_usage:
+                total_tokens_accumulated += message._token_usage.get(
+                    "total_tokens", 0
+                )
 
             tool_calls = getattr(message, "tool_calls", None)
 
@@ -281,9 +304,12 @@ class InferenceClient:
                 else:
                     logger.warning("LLM returned None content, using empty string")
                     content = ""
+                self.last_total_tokens = total_tokens_accumulated
+                self.last_tool_calls_count = tool_calls_count
                 return content
 
             # LLM wants to call tools - execute them
+            tool_calls_count += len(tool_calls)
             tool_names_called = [tc.function.name for tc in tool_calls]
             logger.info(
                 "Calling %d tool(s): %s", len(tool_calls), ", ".join(tool_names_called)
@@ -339,6 +365,8 @@ class InferenceClient:
         logger.warning(
             "Reached maximum iterations (%d) without final answer", max_iterations
         )
+        self.last_total_tokens = total_tokens_accumulated
+        self.last_tool_calls_count = tool_calls_count
         return "Analysis incomplete: Maximum tool calling iterations reached. Please try again with a simpler query."
 
 

--- a/bugzooka/integrations/slack_fetcher.py
+++ b/bugzooka/integrations/slack_fetcher.py
@@ -28,6 +28,7 @@ from bugzooka.integrations.inference_client import (
 )
 from bugzooka.integrations.rag_client_util import get_rag_context
 from bugzooka.integrations.slack_client_base import SlackClientBase
+from bugzooka import telemetry
 from bugzooka.core.utils import (
     to_job_history_url,
     fetch_job_history_stats,
@@ -454,6 +455,11 @@ class SlackMessageFetcher(SlackClientBase):
 
     def _handle_success_viz(self, msg):
         """Post orion visualization links for a successful job run."""
+        start_time = time.time()
+        success = False
+        error_message = None
+        error_type = None
+        msg_user = msg.get("user") or None
         try:
             text = msg.get("text", "")
             ts = msg.get("ts")
@@ -482,8 +488,23 @@ class SlackMessageFetcher(SlackClientBase):
                 thread_ts=ts,
             )
             self.logger.info("Posted orion viz links for successful job")
+            success = True
         except Exception as e:
             self.logger.error("Failed to handle success viz: %s", e)
+            error_message = str(e)
+            error_type = type(e).__name__
+        finally:
+            telemetry.emit({
+                "command": "auto_viz",
+                "trigger_type": "automatic",
+                "channel_id": self.channel_id,
+                "user_id": msg_user,
+                "success": success,
+                "error_message": error_message,
+                "error_type": error_type,
+                "duration_ms": int((time.time() - start_time) * 1000),
+                "retry_count": 0,
+            })
 
     def _process_message(self, msg, enable_inference):
         """Process a single message through the complete pipeline."""
@@ -504,11 +525,36 @@ class SlackMessageFetcher(SlackClientBase):
             lookback = int(value) * factor
             verbose = "verbose" in text_lower
             self.logger.info("Triggering time summary on demand for %s%s", value, unit)
-            self.post_time_summary(
-                thread_ts=ts,
-                lookback_seconds=lookback,
-                verbose=verbose,
-            )
+
+            start_time = time.time()
+            _success = False
+            _error_message = None
+            _error_type = None
+            _total_failures = 0
+            try:
+                _total_failures = self.post_time_summary(
+                    thread_ts=ts,
+                    lookback_seconds=lookback,
+                    verbose=verbose,
+                )
+                _success = True
+            except Exception as e:
+                _error_message = str(e)
+                _error_type = type(e).__name__
+            finally:
+                telemetry.emit({
+                    "command": "summarize",
+                    "trigger_type": "user_initiated",
+                    "channel_id": self.channel_id,
+                    "user_id": user,
+                    "success": _success,
+                    "error_message": _error_message,
+                    "error_type": _error_type,
+                    "duration_ms": int((time.time() - start_time) * 1000),
+                    "retry_count": 0,
+                    "lookback_seconds": lookback,
+                    "total_failures": _total_failures or 0,
+                })
             return ts
 
         # Handle success messages: post orion viz links if available
@@ -524,6 +570,16 @@ class SlackMessageFetcher(SlackClientBase):
             self.logger.info("Not a failure or error job, skipping")
             return ts
 
+        # --- auto_analyze telemetry tracking ---
+        _aa_start = time.time()
+        _aa_success = False
+        _aa_error_message = None
+        _aa_error_type = None
+        _aa_failure_type = None
+        _aa_used_llm = False
+        _aa_total_tokens = 0
+        _aa_retry_count = 0
+
         # Extract and download logs
         analysis = download_and_analyze_logs(text)
         (
@@ -536,7 +592,25 @@ class SlackMessageFetcher(SlackClientBase):
         ) = analysis[:6]
         changepoint_tests = getattr(analysis, "changepoint_tests", None)
         if errors_list is None:
+            telemetry.emit({
+                "command": "auto_analyze",
+                "trigger_type": "automatic",
+                "channel_id": self.channel_id,
+                "user_id": user if user != "Unknown" else None,
+                "success": True,
+                "error_message": None,
+                "error_type": None,
+                "duration_ms": int((time.time() - _aa_start) * 1000),
+                "retry_count": 0,
+                "failure_type": None,
+                "used_llm": False,
+                "total_tokens": 0,
+            })
             return ts
+
+        _aa_failure_type = classify_failure_type(
+            errors_list, categorization_message, is_install_issue
+        )
 
         # For orion/changepoint failures, include visualization link in preview
         viz_url = None
@@ -565,14 +639,40 @@ class SlackMessageFetcher(SlackClientBase):
         self._handle_job_history(thread_ts=ts, current_message=msg)
 
         if is_install_issue or not enable_inference:
+            _aa_success = True
+            telemetry.emit({
+                "command": "auto_analyze",
+                "trigger_type": "automatic",
+                "channel_id": self.channel_id,
+                "user_id": user if user != "Unknown" else None,
+                "success": _aa_success,
+                "error_message": None,
+                "error_type": None,
+                "duration_ms": int((time.time() - _aa_start) * 1000),
+                "retry_count": 0,
+                "failure_type": _aa_failure_type,
+                "used_llm": False,
+                "total_tokens": 0,
+            })
             return ts
 
         try:
             # Process with LLM
-            error_summary = filter_errors_with_llm(errors_list, requires_llm)
+            error_summary, filter_retries = filter_errors_with_llm(
+                errors_list, requires_llm
+            )
 
             # Run agent analysis
-            analysis_response = run_agent_analysis(error_summary)
+            analysis_response, agent_retries = run_agent_analysis(error_summary)
+            _aa_used_llm = True
+            _aa_retry_count = filter_retries + agent_retries
+
+            # Read accumulated token usage
+            try:
+                client = get_inference_client()
+                _aa_total_tokens = client.last_total_tokens
+            except Exception:
+                pass
 
             # Optionally augment with RAG-aware prompt when RAG_IMAGE is set
             combined_response = analysis_response
@@ -610,18 +710,41 @@ class SlackMessageFetcher(SlackClientBase):
 
             # Send final analysis (possibly augmented)
             self._send_analysis_result(combined_response, ts)
+            _aa_success = True
 
         except InferenceAPIUnavailableError as e:
             self.logger.warning(
                 "Skipping LLM analysis due to inference API unavailability: %s", e
             )
             self._send_analysis_unavailable_message(ts)
+            _aa_error_message = str(e)
+            _aa_error_type = "inference_error"
+            _aa_used_llm = True
+            _aa_success = True
         except AgentAnalysisLimitExceededError as e:
             self.logger.warning(
                 "Skipping agent analysis due to iteration/time limits: %s", e
             )
             self._send_analysis_unavailable_message(ts)
+            _aa_error_message = str(e)
+            _aa_error_type = "timeout"
+            _aa_used_llm = True
+            _aa_success = True
 
+        telemetry.emit({
+            "command": "auto_analyze",
+            "trigger_type": "automatic",
+            "channel_id": self.channel_id,
+            "user_id": user if user != "Unknown" else None,
+            "success": _aa_success,
+            "error_message": _aa_error_message,
+            "error_type": _aa_error_type,
+            "duration_ms": int((time.time() - _aa_start) * 1000),
+            "retry_count": _aa_retry_count,
+            "failure_type": _aa_failure_type,
+            "used_llm": _aa_used_llm,
+            "total_tokens": _aa_total_tokens,
+        })
         return ts
 
     def fetch_messages(self, **kwargs):
@@ -699,6 +822,8 @@ class SlackMessageFetcher(SlackClientBase):
     def post_time_summary(self, **kwargs):
         """
         Fetch messages from the last lookback_seconds, aggregate failures by type, and post a summary.
+
+        :return: total_failures count (int)
         """
         try:
             thread_ts: Optional[str] = kwargs.get("thread_ts")
@@ -749,10 +874,13 @@ class SlackMessageFetcher(SlackClientBase):
                         blocks=message_block,
                         thread_ts=thread_ts,
                     )
+            return total_failures
         except SlackApiError as e:
             self.logger.error(f"❌ Slack API Error (summary): {e.response['error']}")
+            return 0
         except Exception as e:
             self.logger.error(f"⚠️ Unexpected Error in summary: {str(e)}")
+            return 0
 
     def run(self, **kwargs):
         """

--- a/bugzooka/integrations/slack_socket_listener.py
+++ b/bugzooka/integrations/slack_socket_listener.py
@@ -7,6 +7,7 @@ import asyncio
 import concurrent.futures
 import logging
 import sys
+import time
 from threading import Lock, Event
 from typing import Dict, Any, Set
 
@@ -25,6 +26,7 @@ from bugzooka.analysis.perf_summary_analyzer import (
     parse_perf_summary_args,
 )
 from bugzooka.integrations.slack_client_base import SlackClientBase
+from bugzooka import telemetry
 
 
 class SlackSocketListener(SlackClientBase):
@@ -104,6 +106,13 @@ class SlackSocketListener(SlackClientBase):
 
         # Check if message contains "analyze pr"
         if "analyze pr" in text.lower():
+            _start = time.time()
+            _success = False
+            _error_message = None
+            _error_type = None
+            _pr_repo = None
+            _total_tokens = 0
+            _tool_calls_count = 0
             try:
                 # Send initial acknowledgment
                 self.client.chat_postMessage(
@@ -160,6 +169,7 @@ class SlackSocketListener(SlackClientBase):
 
                 if analysis_result["success"]:
                     org, repo, pr_number, version = analysis_result["pr_info"]
+                    _pr_repo = f"{org}/{repo}"
                     self.logger.info(
                         f"✅ Sent PR analysis for {org}/{repo}#{pr_number} (OpenShift {version}) to {user}"
                     )
@@ -167,6 +177,18 @@ class SlackSocketListener(SlackClientBase):
                     self.logger.warning(
                         f"⚠️ PR analysis failed: {analysis_result['message']}"
                     )
+                _success = True
+
+                try:
+                    from bugzooka.integrations.inference_client import (
+                        get_inference_client,
+                    )
+
+                    client = get_inference_client()
+                    _total_tokens = client.last_total_tokens
+                    _tool_calls_count = client.last_tool_calls_count
+                except Exception:
+                    pass
 
             except Exception as e:
                 self.logger.error(
@@ -177,10 +199,32 @@ class SlackSocketListener(SlackClientBase):
                     text=f"❌ Unexpected error: {str(e)}",
                     thread_ts=ts,
                 )
+                _error_message = str(e)
+                _error_type = type(e).__name__
+            finally:
+                telemetry.emit({
+                    "command": "analyze_pr",
+                    "trigger_type": "user_initiated",
+                    "channel_id": channel,
+                    "user_id": user,
+                    "success": _success,
+                    "error_message": _error_message,
+                    "error_type": _error_type,
+                    "duration_ms": int((time.time() - _start) * 1000),
+                    "retry_count": 0,
+                    "pr_repo": _pr_repo,
+                    "total_tokens": _total_tokens,
+                    "tool_calls_count": _tool_calls_count,
+                })
             return
 
         # Check if message contains "inspect" for nightly regression analysis
         if "inspect" in text.lower():
+            _start = time.time()
+            _success = False
+            _error_message = None
+            _error_type = None
+            _nightly_version = None
             try:
                 # Send initial acknowledgment
                 self.client.chat_postMessage(
@@ -217,6 +261,7 @@ class SlackSocketListener(SlackClientBase):
                             config,
                             lookback,
                         ) = nightly_info
+                        _nightly_version = nightly_version
                         self.logger.info(
                             f"Sent nightly regression analysis for {nightly_version} to {user}"
                         )
@@ -226,6 +271,7 @@ class SlackSocketListener(SlackClientBase):
                     self.logger.warning(
                         f"Nightly regression analysis failed: {analysis_result['message']}"
                     )
+                _success = True
 
             except Exception as e:
                 self.logger.error(
@@ -236,10 +282,31 @@ class SlackSocketListener(SlackClientBase):
                     text=f"Unexpected error: {str(e)}",
                     thread_ts=ts,
                 )
+                _error_message = str(e)
+                _error_type = "mcp_error"
+            finally:
+                telemetry.emit({
+                    "command": "inspect_nightly",
+                    "trigger_type": "user_initiated",
+                    "channel_id": channel,
+                    "user_id": user,
+                    "success": _success,
+                    "error_message": _error_message,
+                    "error_type": _error_type,
+                    "duration_ms": int((time.time() - _start) * 1000),
+                    "retry_count": 0,
+                    "nightly_version": _nightly_version,
+                })
             return
 
         # Check if message contains "performance summary"
         if "performance summary" in text.lower():
+            _start = time.time()
+            _success = False
+            _error_message = None
+            _error_type = None
+            _configs_count = 0
+            _versions_count = 0
             try:
                 # Send initial acknowledgment
                 self.client.chat_postMessage(
@@ -255,6 +322,8 @@ class SlackSocketListener(SlackClientBase):
                     lookback_days,
                     use_all_configs,
                 ) = parse_perf_summary_args(text)
+                _configs_count = len(configs)
+                _versions_count = len(versions)
 
                 # Run async function in sync context
                 loop = asyncio.new_event_loop()
@@ -293,6 +362,7 @@ class SlackSocketListener(SlackClientBase):
                     self.logger.warning(
                         f"⚠️ Performance summary failed: {result.get('message')}"
                     )
+                _success = True
 
             except Exception as e:
                 self.logger.error(
@@ -303,9 +373,29 @@ class SlackSocketListener(SlackClientBase):
                     text=f"❌ Unexpected error: {str(e)}",
                     thread_ts=ts,
                 )
+                _error_message = str(e)
+                _error_type = "mcp_error"
+            finally:
+                telemetry.emit({
+                    "command": "perf_summary",
+                    "trigger_type": "user_initiated",
+                    "channel_id": channel,
+                    "user_id": user,
+                    "success": _success,
+                    "error_message": _error_message,
+                    "error_type": _error_type,
+                    "duration_ms": int((time.time() - _start) * 1000),
+                    "retry_count": 0,
+                    "configs_count": _configs_count,
+                    "versions_count": _versions_count,
+                })
             return
 
         # Default: Send simple greeting message
+        _start = time.time()
+        _success = False
+        _error_message = None
+        _error_type = None
         try:
             self.client.chat_postMessage(
                 channel=channel,
@@ -317,8 +407,23 @@ class SlackSocketListener(SlackClientBase):
                 thread_ts=ts,
             )
             self.logger.info(f"✅ Sent greeting to {user}")
+            _success = True
         except Exception as e:
             self.logger.error(f"Error sending message: {e}", exc_info=True)
+            _error_message = str(e)
+            _error_type = "slack_api_error"
+        finally:
+            telemetry.emit({
+                "command": "help",
+                "trigger_type": "user_initiated",
+                "channel_id": channel,
+                "user_id": user,
+                "success": _success,
+                "error_message": _error_message,
+                "error_type": _error_type,
+                "duration_ms": int((time.time() - _start) * 1000),
+                "retry_count": 0,
+            })
 
     def _submit_mention_for_processing(self, event: Dict[str, Any]) -> None:
         """

--- a/bugzooka/telemetry/__init__.py
+++ b/bugzooka/telemetry/__init__.py
@@ -1,0 +1,5 @@
+"""Usage telemetry for BugZooka."""
+
+from bugzooka.telemetry.telemetry_client import emit, start, shutdown
+
+__all__ = ["emit", "start", "shutdown"]

--- a/bugzooka/telemetry/telemetry_client.py
+++ b/bugzooka/telemetry/telemetry_client.py
@@ -1,0 +1,219 @@
+"""
+Telemetry client for BugZooka.
+
+Non-blocking event emission to Elasticsearch via a background daemon thread.
+Events are queued and bulk-written on a configurable interval or batch size.
+"""
+
+import logging
+import queue
+import threading
+import time
+from datetime import datetime, timezone
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_queue: queue.Queue = queue.Queue(maxsize=1000)
+_thread: Optional[threading.Thread] = None
+_es_client = None
+_config: Optional[dict] = None
+_channel_team_mappings: dict = {}
+_shutdown_event = threading.Event()
+_started = False
+
+
+def start() -> None:
+    """Initialize and start the telemetry daemon thread."""
+    global _config, _channel_team_mappings, _es_client, _thread, _started
+
+    if _started:
+        return
+
+    from bugzooka.core.config import get_telemetry_config, get_channel_team_mappings
+
+    _config = get_telemetry_config()
+    _channel_team_mappings = get_channel_team_mappings()
+    logger.info("Loaded %d channel-team mapping(s)", len(_channel_team_mappings))
+
+    from opensearchpy import OpenSearch
+
+    _es_client = OpenSearch(
+        _config["es_server"],
+        timeout=30,
+        retry_on_timeout=True,
+        max_retries=2,
+    )
+
+    try:
+        _es_client.info()
+        logger.info("Telemetry ES connection verified: %s", _config["es_server"])
+    except Exception as e:
+        logger.warning(
+            "Telemetry ES connection check failed: %s. Will retry on first flush.", e
+        )
+
+    _ensure_index_template()
+
+    _thread = threading.Thread(
+        target=_flush_thread,
+        daemon=True,
+        name="TelemetryFlusher",
+    )
+    _thread.start()
+    _started = True
+    logger.info(
+        "Telemetry started (index_prefix=%s, flush=%ds, batch=%d)",
+        _config["index_prefix"],
+        _config["flush_interval"],
+        _config["batch_size"],
+    )
+
+
+def emit(event: dict) -> None:
+    """Enqueue a telemetry event. Non-blocking, never raises."""
+    if _config is None:
+        return
+
+    try:
+        channel_id = event.get("channel_id")
+        if channel_id and "team" not in event:
+            event["team"] = _channel_team_mappings.get(channel_id, "unknown")
+
+        if "timestamp" not in event:
+            event["timestamp"] = datetime.now(timezone.utc).isoformat()
+
+        _queue.put_nowait(event)
+        logger.debug(
+            "Telemetry event queued: command=%s, queue_size=%d",
+            event.get("command"),
+            _queue.qsize(),
+        )
+    except queue.Full:
+        logger.warning(
+            "Telemetry queue full, dropping event: %s", event.get("command")
+        )
+    except Exception as e:
+        logger.warning("Telemetry emit error: %s", e)
+
+
+def shutdown() -> None:
+    """Signal the daemon thread to flush remaining events and stop."""
+    global _started
+    if not _started:
+        return
+
+    logger.info("Shutting down telemetry...")
+    _shutdown_event.set()
+
+    if _thread is not None:
+        _thread.join(timeout=15)
+
+    _started = False
+    logger.info("Telemetry shutdown complete")
+
+
+def _flush_thread() -> None:
+    """Daemon thread: drain queue and bulk-write to ES periodically."""
+    flush_interval = _config["flush_interval"]
+    batch_size = _config["batch_size"]
+
+    while not _shutdown_event.is_set():
+        _shutdown_event.wait(timeout=flush_interval)
+        logger.debug("Telemetry flush cycle, queue_size=%d", _queue.qsize())
+        _drain_and_flush(batch_size)
+
+    remaining = _queue.qsize()
+    if remaining:
+        logger.info("Telemetry final flush: draining %d remaining event(s)", remaining)
+    _drain_and_flush(max(remaining, batch_size))
+
+
+def _drain_and_flush(batch_size: int) -> None:
+    """Drain up to batch_size events from queue and write to ES."""
+    batch = []
+    while len(batch) < batch_size:
+        try:
+            event = _queue.get_nowait()
+            batch.append(event)
+        except queue.Empty:
+            break
+
+    if batch:
+        _bulk_write(batch)
+
+
+def _bulk_write(events: list) -> None:
+    """Write a batch of events to Elasticsearch."""
+    if _es_client is None:
+        logger.warning(
+            "Telemetry ES client not initialized, dropping %d events", len(events)
+        )
+        return
+
+    index_name = "{prefix}-{date}".format(
+        prefix=_config["index_prefix"],
+        date=datetime.now(timezone.utc).strftime("%Y.%m"),
+    )
+
+    actions = [{"_index": index_name, "_source": event} for event in events]
+
+    try:
+        from opensearchpy.helpers import bulk
+
+        success, errors = bulk(_es_client, actions, raise_on_error=False)
+        if errors:
+            logger.warning("Telemetry bulk write had %d errors", len(errors))
+        else:
+            logger.debug("Telemetry flushed %d events to %s", success, index_name)
+    except Exception as e:
+        logger.error("Telemetry bulk write failed: %s. Dropping %d events.", e, len(events))
+
+
+def _ensure_index_template() -> None:
+    """Create ES index template for telemetry indices (best-effort)."""
+    if _es_client is None:
+        return
+
+    template_name = f"{_config['index_prefix']}-template"
+    template_body = {
+        "index_patterns": [f"{_config['index_prefix']}-*"],
+        "settings": {
+            "number_of_shards": 1,
+            "number_of_replicas": 1,
+        },
+        "mappings": {
+            "properties": {
+                "timestamp": {"type": "date"},
+                "command": {"type": "keyword"},
+                "trigger_type": {"type": "keyword"},
+                "channel_id": {"type": "keyword"},
+                "user_id": {"type": "keyword"},
+                "team": {"type": "keyword"},
+                "success": {"type": "boolean"},
+                "error_message": {"type": "text"},
+                "error_type": {"type": "keyword"},
+                "duration_ms": {"type": "long"},
+                "retry_count": {"type": "integer"},
+                "failure_type": {"type": "keyword"},
+                "used_llm": {"type": "boolean"},
+                "total_tokens": {"type": "integer"},
+                "lookback_seconds": {"type": "integer"},
+                "total_failures": {"type": "integer"},
+                "pr_repo": {"type": "keyword"},
+                "tool_calls_count": {"type": "integer"},
+                "nightly_version": {"type": "keyword"},
+                "configs_count": {"type": "integer"},
+                "versions_count": {"type": "integer"},
+            }
+        },
+    }
+
+    try:
+        _es_client.indices.put_template(
+            name=template_name,
+            body=template_body,
+        )
+        logger.info("Telemetry index template created: %s", template_name)
+    except Exception as e:
+        logger.warning("Failed to create telemetry index template: %s", e)

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,6 @@ python-dotenv==1.0.1
 PyYAML==6.0.2
 xmltodict==0.14.2
 logmine==0.4.1
+
+# Telemetry
+opensearch-py>=2.0,<3.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,11 @@ import json
 import pytest
 from unittest.mock import patch
 
-from bugzooka.core.config import get_es_channel_mappings
+from bugzooka.core.config import (
+    get_es_channel_mappings,
+    get_telemetry_config,
+    get_channel_team_mappings,
+)
 
 
 class TestGetESChannelMappings:
@@ -182,3 +186,76 @@ class TestGetESChannelMappings:
             assert result["C_TEAM_A"]["es_server"] == result["C_TEAM_B"]["es_server"]
             assert result["C_TEAM_A"]["es_metadata_index"] != result["C_TEAM_B"]["es_metadata_index"]
             assert result["C_TEAM_A"]["es_benchmark_index"] != result["C_TEAM_B"]["es_benchmark_index"]
+
+
+class TestGetTelemetryConfig:
+    """Test get_telemetry_config function."""
+
+    def test_valid_config_with_defaults(self):
+        """Test valid config with only required TELEMETRY_ES_SERVER set."""
+        env = {"TELEMETRY_ES_SERVER": "https://es.example.com:9200"}
+        with patch.dict(os.environ, env, clear=True):
+            config = get_telemetry_config()
+
+            assert config["es_server"] == "https://es.example.com:9200"
+            assert config["index_prefix"] == "bugzooka-telemetry"
+            assert config["flush_interval"] == 30
+            assert config["batch_size"] == 50
+
+    def test_valid_config_with_overrides(self):
+        """Test config with all values overridden."""
+        env = {
+            "TELEMETRY_ES_SERVER": "https://es.example.com:9200",
+            "TELEMETRY_ES_INDEX_PREFIX": "custom-prefix",
+            "TELEMETRY_FLUSH_INTERVAL": "10",
+            "TELEMETRY_BATCH_SIZE": "100",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = get_telemetry_config()
+
+            assert config["index_prefix"] == "custom-prefix"
+            assert config["flush_interval"] == 10
+            assert config["batch_size"] == 100
+
+    def test_missing_es_server_raises_error(self):
+        """Test that missing TELEMETRY_ES_SERVER raises ValueError."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="TELEMETRY_ES_SERVER is required"):
+                get_telemetry_config()
+
+    def test_es_server_with_credentials_in_url(self):
+        """Test ES server URL with embedded credentials."""
+        url = "https://user:pass@es.example.com:9200"
+        with patch.dict(os.environ, {"TELEMETRY_ES_SERVER": url}, clear=True):
+            config = get_telemetry_config()
+            assert config["es_server"] == url
+
+
+class TestGetChannelTeamMappings:
+    """Test get_channel_team_mappings function."""
+
+    def test_valid_mappings(self):
+        """Test parsing valid channel-team mappings."""
+        mappings = json.dumps({"C12345": "OCP-PerfScale", "C67890": "Telco"})
+        with patch.dict(os.environ, {"CHANNEL_TEAM_MAPPINGS": mappings}):
+            result = get_channel_team_mappings()
+
+            assert result == {"C12345": "OCP-PerfScale", "C67890": "Telco"}
+
+    def test_missing_env_var_returns_empty(self):
+        """Test that missing CHANNEL_TEAM_MAPPINGS returns empty dict."""
+        with patch.dict(os.environ, {}, clear=True):
+            result = get_channel_team_mappings()
+            assert result == {}
+
+    def test_invalid_json_returns_empty(self):
+        """Test that invalid JSON returns empty dict with warning."""
+        with patch.dict(os.environ, {"CHANNEL_TEAM_MAPPINGS": "not json"}):
+            result = get_channel_team_mappings()
+            assert result == {}
+
+    def test_non_dict_json_returns_empty(self):
+        """Test that non-dict JSON returns empty dict."""
+        with patch.dict(os.environ, {"CHANNEL_TEAM_MAPPINGS": '["a","b"]'}):
+            result = get_channel_team_mappings()
+            assert result == {}

--- a/tests/test_slack_fetcher.py
+++ b/tests/test_slack_fetcher.py
@@ -91,11 +91,11 @@ def run_slack_fetcher_test(
             # Mock inference functions to return successful responses
             filter_mock = patch(
                 "bugzooka.integrations.slack_fetcher.filter_errors_with_llm",
-                return_value="Some filtered error summary from logs",
+                return_value=("Some filtered error summary from logs", 0),
             )
             analysis_mock = patch(
                 "bugzooka.integrations.slack_fetcher.run_agent_analysis",
-                return_value="Some recommended actions.",
+                return_value=("Some recommended actions.", 0),
             )
 
         with mock_analysis:

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,277 @@
+"""
+Tests for the telemetry module.
+
+Tests emit(), start(), shutdown(), team enrichment, timestamp enrichment,
+and queue overflow behavior without requiring an actual ES connection.
+"""
+
+import os
+import time
+import json
+import queue
+from unittest.mock import patch, MagicMock
+from datetime import datetime, timezone
+
+import pytest
+
+from bugzooka.telemetry import telemetry_client
+
+
+@pytest.fixture(autouse=True)
+def reset_telemetry_state():
+    """Reset module-level telemetry state before and after each test."""
+    telemetry_client._config = None
+    telemetry_client._channel_team_mappings = {}
+    telemetry_client._es_client = None
+    telemetry_client._started = False
+    telemetry_client._shutdown_event.clear()
+    telemetry_client._thread = None
+    # Drain any leftover events
+    while not telemetry_client._queue.empty():
+        try:
+            telemetry_client._queue.get_nowait()
+        except queue.Empty:
+            break
+    yield
+    # Cleanup after test
+    if telemetry_client._started:
+        telemetry_client._shutdown_event.set()
+        if telemetry_client._thread:
+            telemetry_client._thread.join(timeout=2)
+    telemetry_client._config = None
+    telemetry_client._channel_team_mappings = {}
+    telemetry_client._es_client = None
+    telemetry_client._started = False
+    telemetry_client._shutdown_event.clear()
+    telemetry_client._thread = None
+
+
+class TestEmit:
+    """Test the emit() function."""
+
+    def test_emit_noop_before_start(self):
+        """emit() should silently return when telemetry hasn't started."""
+        telemetry_client.emit({"command": "test"})
+        assert telemetry_client._queue.empty()
+
+    def test_emit_queues_event(self):
+        """emit() should place event on the queue when config is set."""
+        telemetry_client._config = {"es_server": "http://localhost:9200"}
+
+        telemetry_client.emit({"command": "analyze_pr", "success": True})
+
+        assert telemetry_client._queue.qsize() == 1
+        event = telemetry_client._queue.get_nowait()
+        assert event["command"] == "analyze_pr"
+        assert event["success"] is True
+
+    def test_emit_adds_timestamp(self):
+        """emit() should add a UTC timestamp if not present."""
+        telemetry_client._config = {"es_server": "http://localhost:9200"}
+
+        telemetry_client.emit({"command": "help"})
+
+        event = telemetry_client._queue.get_nowait()
+        assert "timestamp" in event
+        # Should be parseable as ISO format
+        ts = datetime.fromisoformat(event["timestamp"])
+        assert ts.tzinfo is not None
+
+    def test_emit_preserves_existing_timestamp(self):
+        """emit() should not overwrite an existing timestamp."""
+        telemetry_client._config = {"es_server": "http://localhost:9200"}
+        custom_ts = "2026-01-01T00:00:00+00:00"
+
+        telemetry_client.emit({"command": "help", "timestamp": custom_ts})
+
+        event = telemetry_client._queue.get_nowait()
+        assert event["timestamp"] == custom_ts
+
+    def test_emit_enriches_team_from_channel_mapping(self):
+        """emit() should add team based on channel_id mapping."""
+        telemetry_client._config = {"es_server": "http://localhost:9200"}
+        telemetry_client._channel_team_mappings = {"C12345": "OCP-PerfScale"}
+
+        telemetry_client.emit({"command": "analyze_pr", "channel_id": "C12345"})
+
+        event = telemetry_client._queue.get_nowait()
+        assert event["team"] == "OCP-PerfScale"
+
+    def test_emit_sets_unknown_team_for_unmapped_channel(self):
+        """emit() should set team to 'unknown' for unmapped channels."""
+        telemetry_client._config = {"es_server": "http://localhost:9200"}
+        telemetry_client._channel_team_mappings = {"C12345": "OCP-PerfScale"}
+
+        telemetry_client.emit({"command": "help", "channel_id": "C99999"})
+
+        event = telemetry_client._queue.get_nowait()
+        assert event["team"] == "unknown"
+
+    def test_emit_does_not_overwrite_existing_team(self):
+        """emit() should not overwrite team if already set in event."""
+        telemetry_client._config = {"es_server": "http://localhost:9200"}
+        telemetry_client._channel_team_mappings = {"C12345": "OCP-PerfScale"}
+
+        telemetry_client.emit({
+            "command": "help",
+            "channel_id": "C12345",
+            "team": "CustomTeam",
+        })
+
+        event = telemetry_client._queue.get_nowait()
+        assert event["team"] == "CustomTeam"
+
+    def test_emit_drops_on_full_queue(self):
+        """emit() should drop events when queue is full without raising."""
+        telemetry_client._config = {"es_server": "http://localhost:9200"}
+
+        # Fill the queue
+        for i in range(1000):
+            telemetry_client._queue.put_nowait({"command": f"fill_{i}"})
+
+        # This should not raise
+        telemetry_client.emit({"command": "dropped"})
+
+        assert telemetry_client._queue.qsize() == 1000
+
+
+class TestDrainAndFlush:
+    """Test the _drain_and_flush() function."""
+
+    def test_drain_empties_queue_into_bulk_write(self):
+        """_drain_and_flush should drain events and call _bulk_write."""
+        telemetry_client._config = {"index_prefix": "test", "flush_interval": 5, "batch_size": 50}
+        telemetry_client._es_client = MagicMock()
+
+        telemetry_client._queue.put_nowait({"command": "test1"})
+        telemetry_client._queue.put_nowait({"command": "test2"})
+
+        with patch.object(telemetry_client, "_bulk_write") as mock_write:
+            telemetry_client._drain_and_flush(50)
+
+            mock_write.assert_called_once()
+            events = mock_write.call_args[0][0]
+            assert len(events) == 2
+            assert events[0]["command"] == "test1"
+            assert events[1]["command"] == "test2"
+
+    def test_drain_respects_batch_size(self):
+        """_drain_and_flush should drain at most batch_size events."""
+        telemetry_client._config = {"index_prefix": "test"}
+        telemetry_client._es_client = MagicMock()
+
+        for i in range(10):
+            telemetry_client._queue.put_nowait({"command": f"event_{i}"})
+
+        with patch.object(telemetry_client, "_bulk_write") as mock_write:
+            telemetry_client._drain_and_flush(3)
+
+            events = mock_write.call_args[0][0]
+            assert len(events) == 3
+
+        # 7 should remain in queue
+        assert telemetry_client._queue.qsize() == 7
+
+    def test_drain_does_nothing_on_empty_queue(self):
+        """_drain_and_flush should not call _bulk_write when queue is empty."""
+        with patch.object(telemetry_client, "_bulk_write") as mock_write:
+            telemetry_client._drain_and_flush(50)
+            mock_write.assert_not_called()
+
+
+class TestBulkWrite:
+    """Test the _bulk_write() function."""
+
+    def test_bulk_write_drops_when_client_none(self):
+        """_bulk_write should log warning and return when ES client is None."""
+        telemetry_client._es_client = None
+        telemetry_client._config = {"index_prefix": "test"}
+
+        # Should not raise
+        telemetry_client._bulk_write([{"command": "test"}])
+
+    def test_bulk_write_generates_correct_index_name(self):
+        """_bulk_write should use monthly index pattern."""
+        mock_client = MagicMock()
+        telemetry_client._es_client = mock_client
+        telemetry_client._config = {"index_prefix": "bugzooka-telemetry"}
+
+        mock_bulk_fn = MagicMock(return_value=(1, []))
+        mock_helpers = MagicMock()
+        mock_helpers.bulk = mock_bulk_fn
+
+        import sys
+        with patch.dict(sys.modules, {"opensearchpy.helpers": mock_helpers}):
+            telemetry_client._bulk_write([{"command": "test"}])
+
+            actions = mock_bulk_fn.call_args[0][1]
+            expected_prefix = "bugzooka-telemetry-"
+            assert actions[0]["_index"].startswith(expected_prefix)
+
+
+def _mock_opensearch_modules():
+    """Create mock opensearchpy modules for tests that need start()."""
+    import sys
+
+    mock_opensearch_cls = MagicMock()
+    mock_opensearch_cls.return_value = MagicMock()
+
+    mock_opensearchpy = MagicMock()
+    mock_opensearchpy.OpenSearch = mock_opensearch_cls
+
+    return patch.dict(sys.modules, {
+        "opensearchpy": mock_opensearchpy,
+        "opensearchpy.helpers": MagicMock(),
+    })
+
+
+class TestStartShutdown:
+    """Test start() and shutdown() lifecycle."""
+
+    def test_start_creates_thread(self):
+        """start() should create and start the daemon thread."""
+        env = {"TELEMETRY_ES_SERVER": "http://localhost:9200"}
+        with patch.dict(os.environ, env, clear=True):
+            with _mock_opensearch_modules():
+                telemetry_client.start()
+
+                assert telemetry_client._started is True
+                assert telemetry_client._thread is not None
+                assert telemetry_client._thread.is_alive()
+                assert telemetry_client._thread.daemon is True
+
+                telemetry_client.shutdown()
+
+    def test_start_is_idempotent(self):
+        """Calling start() twice should not create a second thread."""
+        env = {"TELEMETRY_ES_SERVER": "http://localhost:9200"}
+        with patch.dict(os.environ, env, clear=True):
+            with _mock_opensearch_modules():
+                telemetry_client.start()
+                first_thread = telemetry_client._thread
+
+                telemetry_client.start()
+                assert telemetry_client._thread is first_thread
+
+                telemetry_client.shutdown()
+
+    def test_shutdown_sets_started_false(self):
+        """shutdown() should mark telemetry as stopped."""
+        env = {"TELEMETRY_ES_SERVER": "http://localhost:9200"}
+        with patch.dict(os.environ, env, clear=True):
+            with _mock_opensearch_modules():
+                telemetry_client.start()
+                telemetry_client.shutdown()
+
+                assert telemetry_client._started is False
+
+    def test_shutdown_noop_when_not_started(self):
+        """shutdown() should do nothing when telemetry was never started."""
+        telemetry_client.shutdown()
+        assert telemetry_client._started is False
+
+    def test_start_fails_without_es_server(self):
+        """start() should raise ValueError when TELEMETRY_ES_SERVER is not set."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="TELEMETRY_ES_SERVER is required"):
+                telemetry_client.start()


### PR DESCRIPTION
Description:       

Feature to add metrics collection from Bugzooka to understand its usage metrics across teams ([Jira Issue Tracker](https://redhat.atlassian.net/browse/PERFSCALE-4561) ). As a part of this feature the following are implemented:
  - Events are emitted to OpenSearch for every BugZooka command           
  - Each event would capture command name, team, user, success/failure, duration, token usage, retry counts, and command-specific metadata
  - To achieve this , we use a background daemon thread with an in-memory queue which periodically fetches events from the queue and performs a bulk write to the ES server.
  
  For each command the following is the json event structure emitted to the ES server:
  {                                                                                                                                                                                                                  
    "command": "auto_analyze",                                                                                                                                                                                       
    "trigger_type": "automatic",                                                                                                                                                                                     
    "channel_id": "C12345",                                                                                                                                                                                          
    "user_id": "U12345",                                                                                                                                                                                             
    "team": "OCP-PerfScale",                                                                                                                                                                                         
    "timestamp": "2026-05-19T10:30:00+00:00",
    "success": true,                                                                                                                                                                                                 
    "error_message": null,
    "error_type": null,                                                                                                                                                                                              
    "duration_ms": 12500,                                                                                                                                                                                            
    "retry_count": 0                                                                                                                                                                                                 
  }   

In addition to these common fields, each command emits command-specific metrics specific to its workflow — such as total_tokens and tool_calls_count for analyze_pr, failure_type and used_llm for auto_analyze, etc.                                                                                                                                                                                                              
     
**Testing**       

- Tested Locally and uploaded event to QE ES Server
<img width="1512" height="949" alt="image" src="https://github.com/user-attachments/assets/3b8631f2-56fc-4629-91c8-7cd4799212a8" />
                                                                                                                                                                                                       