### PR TITLE
fixing auto_viz error 

### DIFF
--- a/bugzooka/integrations/slack_fetcher.py
+++ b/bugzooka/integrations/slack_fetcher.py
@@ -466,10 +466,12 @@ class SlackMessageFetcher(SlackClientBase):
 
             view_url, _ = extract_job_details(text)
             if not view_url:
+                success = True
                 return
 
             viz_urls = construct_all_orion_viz_urls(view_url)
             if not viz_urls:
+                success = True
                 return
 
             header_text = ":chart_with_upwards_trend: *Orion Visualization*\n"


### PR DESCRIPTION
**Description** 

 When auto_viz found no viz artifacts , the function returned early, emitting a telemetry event with success=False and no error_type/error_message. The dashboard saw these as failures with no root cause. 
 
 **Fix**
 
 The fix sets success=True before those early returns since "no viz found" is normal behavior, not a failure.