### PR TITLE
Fix MCP dependency version conflict causing ImportError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,8 +20,7 @@ rh-py-commons>=0.5.0
 
 # LangChain ecosystem (MCP + tools)
 langchain-core>=1.3.0
-langchain-mcp-adapters>=0.2.2
-mcp==1.12.4
+langchain-mcp-adapters>=0.3.0
 
 # ML / Embeddings
 faiss-cpu==1.12.0


### PR DESCRIPTION
Clash between `mcp` and `langchain-mcp-adapters` was causing an ImportError when BugZooka was deployed on OpenShift. Fix: remove `mcp` requirement and let `langchain` decide which version to take. Works on test OpenShift cluster.