### PR TITLE
Fix full error log file upload and inline rendering for non-changepoi…

### DIFF
--- a/bugzooka/integrations/slack_fetcher.py
+++ b/bugzooka/integrations/slack_fetcher.py
@@ -240,9 +240,7 @@ class SlackMessageFetcher(SlackClientBase):
             header_text += f"<{viz_url}|View Changepoint Visualization>\n"
         header_text += "\nError Logs Preview"
 
-        needs_file = errors_for_file != errors_preview and (
-            is_changepoint or len(errors_for_file) > preview_limit
-        )
+        needs_file = errors_for_file != errors_preview or len(errors_for_file) > preview_limit
 
         # Always post the preview message first
         message_block = self.get_slack_message_blocks(
@@ -301,9 +299,12 @@ class SlackMessageFetcher(SlackClientBase):
     def _upload_full_error_log(self, content, max_ts):
         """Upload full error log file to the thread."""
         self.logger.info("Uploading full error log file")
+        clean_content = re.sub(r'\x1b\[[0-9;]*[a-zA-Z]', '', content)
+        clean_content = re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]', '', clean_content)
+        clean_content = re.sub(r'[^\u0000-\uffff]', '', clean_content)
         self.client.files_upload_v2(
             channel=self.channel_id,
-            content=content,
+            content=clean_content,
             filename="full_errors.txt",
             title="Full Error Log",
             thread_ts=max_ts,


### PR DESCRIPTION
## Summary

- Restores the `full_errors.txt` file attachment for non-changepoint failures (logjuicer, logmine, cluster-operator error paths) which was broken since 0b73e6c
- Sanitizes uploaded file content so Slack renders it as an inline expandable snippet instead of a binary download card

## Root Cause

The `needs_file` condition in `_send_error_logs_preview()` used `and` to gate on `errors_for_file != errors_preview`. For all non-changepoint failure paths, `full_errors_for_file` is `None`, so `errors_for_file` falls back to `errors_preview` — making them identical and `needs_file` always `False`. No file was ever uploaded for these failures, even when the preview truncated the content.

**Found by:** Testing BugZooka against real Prow failures on a test Slack channel. A ROSA cluster install failure and a telco virt-6nodes orion-report failure both showed truncated previews with no full log attached. Tracing the code and git history (`git show 0b73e6c`) revealed the regression — the original condition was `needs_file = len(errors_for_file) > preview_limit` which worked correctly, but was changed to an `and` gate that silently broke non-changepoint uploads.

**Rendering fix found by:** After restoring the file upload, certain jobs rendered the file as a binary download card instead of an inline snippet. Testing with multiple real Prow jobs identified three categories of non-text content in build logs that trigger Slack's binary detection:
- ANSI escape codes (`\x1b[1m`, `\x1b[31m`) from Prow colored output
- Control characters from broken/corrupted log streams
- Emojis (🔍, 👋) logged by tools like kube-burner

## Changes

| File | Change |
|------|--------|
| `bugzooka/integrations/slack_fetcher.py` | `and` → `or` in `needs_file` condition; sanitize file upload content (strip ANSI, control chars, emojis) |

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Long non-CP error (logjuicer/logmine/build log) | No file upload | File uploaded (inline snippet) |
| Cluster operator errors (long) | No file upload | File uploaded (inline snippet) |
| CP with report summary (different content) | File uploaded | Unchanged |
| CP without report summary (short, fits preview) | No upload | Unchanged |
| Short non-CP error (fits in preview) | No upload | Unchanged |

## Test plan

- [x] All 96 existing tests pass
- [x] Tested on Slack: changepoint failure (aws-5.0 payload-control-plane-6nodes) — inline snippet with viz links
- [x] Tested on Slack: non-CP failure (metal-5.0 daily-virt-6nodes, missing clusteroperators.json) — file now uploaded, inline
- [x] Tested on Slack: non-CP failure (rosa-4.22 build-farm-114nodes, ANSI codes in build log) — file now uploaded, inline
- [x] Tested on Slack: non-CP failure (metal-5.0 virt-density-nomount, emojis in kube-burner log) — file now uploaded, inline
- [x] Verified content sanitization preserves all log text, timestamps, error messages, JSON, URLs — only invisible formatting and decorative characters removed

/cc @vishnuchalla 