### PR TITLE
Support multiple viz HTML files per orion step directory

### DIFF
--- a/bugzooka/analysis/log_summarizer.py
+++ b/bugzooka/analysis/log_summarizer.py
@@ -239,11 +239,20 @@ def construct_all_orion_viz_urls(view_url):
             except Exception:
                 continue
             html_files = [f for f in files if f.endswith(".html")]
-            if html_files:
+            if not html_files:
+                continue
+            artifacts_url = f"{GCSWEB_BASE_URL}{step_artifacts.replace('gs://', '')}"
+            if len(html_files) == 1:
                 html_name = gcs_basename(html_files[0])
                 test_name = strip_step_prefixes(folder)
-                artifacts_url = f"{GCSWEB_BASE_URL}{step_artifacts.replace('gs://', '')}"
                 viz_urls[test_name] = f"{artifacts_url}{html_name}"
+            else:
+                for html_file in html_files:
+                    html_name = gcs_basename(html_file)
+                    test_name = strip_step_prefixes(
+                        html_name.removesuffix("_viz.html")
+                    )
+                    viz_urls[test_name] = f"{artifacts_url}{html_name}"
 
         return viz_urls if viz_urls else None
     except Exception as e:
@@ -279,6 +288,15 @@ def _construct_single_viz_url(view_url, step_name):
                     f"{folder}/{candidate}/artifacts/"
                 )
                 html_files = [f for f in files if f.endswith(".html")]
+                if len(html_files) > 1:
+                    viz_urls = {}
+                    for html_file in html_files:
+                        html_name = gcs_basename(html_file)
+                        test_name = strip_step_prefixes(
+                            html_name.removesuffix("_viz.html")
+                        )
+                        viz_urls[test_name] = f"{artifacts_url}{html_name}"
+                    return viz_urls
                 if html_files:
                     return f"{artifacts_url}{gcs_basename(html_files[0])}"
                 return artifacts_url


### PR DESCRIPTION
## Summary

- When a single Orion step runs multiple test configs (e.g. telco's `oslat-changepoint.yaml` with `telco-oslat-latency` and `telco-oslat-availability`), it produces multiple `_viz.html` files in the same artifacts directory
- Previously `construct_all_orion_viz_urls()` only picked up `html_files[0]` — the first HTML per step directory
- Now when multiple HTMLs exist in one step, iterates all of them and derives display names from filenames (strip `_viz.html` suffix + `strip_step_prefixes`). Single-HTML steps still use the folder name for backward compatibility with perfscale jobs.

## What changes

| Scenario | Before | After |
|----------|--------|-------|
| Perfscale success (1 HTML per step) | Shows all step links | Unchanged |
| Telco success (2 HTMLs in 1 step) | Shows only first HTML | Shows both |
| Deferred orion-report failure | Same as above | Same as above |

## Test plan

- [x] All 96 existing tests pass
- [x] Verified against real telco artifact structure (`#2074463759547502592`)
- [x] Confirmed backward compatibility with perfscale naming (`cluster-density`, `node-density`, etc.)
- [x] Manual verification on test Slack channel with telco success job

Relates to: PERFSCALE-5191
/cc @vishnuchalla 